### PR TITLE
Update ivalue_inl.h

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef Q_SLOT
+#undef slots
+
 #include <condition_variable>
 #include <memory>
 #include <optional>
@@ -2551,3 +2554,6 @@ TypePtr IValue::type() const {
 }
 
 } // namespace c10
+
+#ifdef Q_SLOT
+#define slots Q_SLOTS


### PR DESCRIPTION
fix the problem when you include Qt file,
The macro name "slots" is conficted with the Variable name “slots” and "_slots"

Fixes #ISSUE_NUMBER
